### PR TITLE
fix: modules filtered formatting when force-all is enabled #93

### DIFF
--- a/src/scripts/filter.sh
+++ b/src/scripts/filter.sh
@@ -116,7 +116,7 @@ if [ "$SH_FORCE_ALL" -eq 1 ] || { [ "$SH_REPORTING_WINDOW" != "" ] && [ "$(curl 
             module_dots="${module_dots::-1}"
         fi
 
-        printf "%s" "$module_dots" >> "$SH_MODULES_FILTERED"
+        printf "%s\\n" "$module_dots" >> "$SH_MODULES_FILTERED"
     done
 else
     pip install --quiet --disable-pip-version-check --no-input wildmatch=="$SH_WILDMATCH_VERSION"


### PR DESCRIPTION
## what

fix force-all feature, which is currently broken; the filter script is not properly formatting the filtered modules file in filter script.
 

## why

basically, add newline character to the printf responsible for generating the filtered modules file before the reduce script

## references

N/A